### PR TITLE
feat: Implement new connection flow and fix startup error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,97 +1,168 @@
-import { makeWASocket, DisconnectReason, useMultiFileAuthState } from '@whiskeysockets/baileys'
-import pino from 'pino'
-import qrcode from 'qrcode-terminal'
-import fs from 'fs-extra'
-import path from 'path'
-import chalk from 'chalk'
-import config from './config.js'
-import { loadPlugins, executeCommand } from './lib/pluginManager.js'
-import { handleMessage } from './lib/messageHandler.js'
-import ErrorHandler from './lib/errorHandler.js'
+// --- New Imports for Connection Logic ---
+import {
+  makeWASocket,
+  DisconnectReason,
+  useMultiFileAuthState,
+  fetchLatestBaileysVersion,
+  makeCacheableSignalKeyStore,
+  Browsers
+} from '@whiskeysockets/baileys';
+import { Boom } from '@hapi/boom';
+import pino from 'pino';
+import qrcode from 'qrcode-terminal';
+import chalk from 'chalk';
+import readline from 'readline';
+import pkgPhone from 'google-libphonenumber';
 
-const { state, saveCreds } = await useMultiFileAuthState(config.sessionPath)
+// --- Original Imports for Plugin System ---
+import config from './config.js';
+import { loadPlugins } from './lib/pluginManager.js';
+import { handleMessage } from './lib/messageHandler.js';
+import ErrorHandler from './lib/errorHandler.js';
 
-let sock
-let errorHandler
-const plugins = new Map()
+// --- Logger Setup ---
+const logger = pino({ level: 'silent' });
 
-async function startBot() {
-  try {
-    sock = makeWASocket({
-      auth: state,
-      logger: pino({ level: 'silent' })
-    })
+// --- Original Globals for Plugin System ---
+const { state, saveCreds } = await useMultiFileAuthState(config.sessionPath);
+let sock;
+let errorHandler;
+const plugins = new Map();
 
-    // Inicializar manejador de errores
-    errorHandler = new ErrorHandler(sock)
+// --- Main Connection Function ---
+async function connectToWhatsApp() {
+  const { version, isLatest } = await fetchLatestBaileysVersion();
+  console.log(`[info] Usando Baileys v${version.join('.')}, ¿es la última versión?: ${isLatest}`);
 
-  sock.ev.on('connection.update', (update) => {
-    const { connection, lastDisconnect, qr } = update
+  const PhoneNumberUtil = pkgPhone.PhoneNumberUtil;
+  const phoneUtil = PhoneNumberUtil.getInstance();
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const ask = (q) => new Promise(res => rl.question(q, ans => res(ans.trim())));
+
+  let option = null;
+  let phoneNumber = null;
+
+  if (!state.creds.registered) {
+    const menuDesign = `${chalk.cyanBright('╭─────────────────────────────◉')}\n`
+      + `${chalk.cyanBright('│')} ${chalk.red.bgBlueBright.bold('    ⚙ MÉTODO DE CONEXIÓN BOT    ')}\n`
+      + `${chalk.cyanBright('│')} 「 🗯 」${chalk.yellow('Selecciona cómo quieres conectarte')}\n`
+      + `${chalk.cyanBright('│')} 「 📲 」${chalk.yellow.bgRed.bold('1. Escanear Código QR')}\n`
+      + `${chalk.cyanBright('│')} 「 🔛 」${chalk.red.bgGreenBright.bold('2. Código de Emparejamiento')}\n`
+      + `${chalk.cyanBright('│')}\n`
+      + `${chalk.cyanBright('╰─────────────────────────────◉')}\n`;
+    do {
+      option = await ask(menuDesign + chalk.green('Ingresa una opción (1-2): '));
+      if (!/^[1-2]$/.test(option)) console.log(chalk.red('Ingresa 1 o 2.'));
+    } while (!['1','2'].includes(option));
+
+    if (option === '2') {
+      let valid = false;
+      while (!valid) {
+        phoneNumber = await ask(chalk.green('Ingresa tu número con código de país (ej +57300xxxxxxx): '));
+        phoneNumber = phoneNumber.replace(/\s+/g, '');
+        if (!phoneNumber.startsWith('+')) phoneNumber = '+' + phoneNumber.replace(/[^\d]/g,'');
+        try {
+          valid = phoneUtil.isValidNumber(phoneUtil.parseAndKeepRawInput(phoneNumber));
+        } catch {
+          valid = false;
+        }
+        if (!valid) console.log(chalk.red('Número inválido o formato no reconocido, intenta nuevamente.'));
+      }
+    }
+    rl.close();
+  } else {
+    console.log(chalk.gray('[info] Sesión existente. Omitiendo menú.'));
+  }
+
+  const usingCode = option === '2';
+
+  sock = makeWASocket({
+    version,
+    auth: {
+      creds: state.creds,
+      keys: makeCacheableSignalKeyStore(state.keys, logger)
+    },
+    logger,
+    browser: usingCode ? Browsers.macOS('Safari') : ['MiBot', 'Chrome', '1.0.0'],
+  });
+
+  errorHandler = new ErrorHandler(sock);
+
+  if (usingCode && !sock.authState.creds.registered) {
+    const digits = phoneNumber.replace(/\D/g, '');
+    console.log(chalk.cyan(`[info] Solicitando código de emparejamiento para ${digits}...`));
+    setTimeout(async () => {
+      try {
+        const code = await sock.requestPairingCode(digits);
+        console.log(chalk.bold.white(chalk.bgMagenta('✧ CÓDIGO DE VINCULACIÓN ✧')), chalk.bold.white(code?.match(/.{1,4}/g)?.join('-') || code));
+      } catch (e) {
+        console.error(chalk.red('[error] Error al solicitar el código:'), e);
+        connectToWhatsApp(); // Retry connection
+      }
+    }, 3000);
+  }
+
+  // --- Original Event Handlers ---
+  sock.ev.on('connection.update', async (update) => {
+    const { connection, lastDisconnect, qr } = update;
     
-    if (qr) {
-      console.log(chalk.yellow('Escanea el código QR con WhatsApp:'))
-      qrcode.generate(qr, { small: true })
+    if (qr && !usingCode) {
+      console.log(chalk.yellow('Escanea el código QR con WhatsApp:'));
+      qrcode.generate(qr, { small: true });
     }
     
     if (connection === 'close') {
-      const shouldReconnect = (lastDisconnect?.error)?.output?.statusCode !== DisconnectReason.loggedOut
-      console.log(chalk.red('Conexión cerrada debido a'), lastDisconnect.error, chalk.yellow('Reconectando...'), shouldReconnect)
+      const statusCode = (lastDisconnect?.error instanceof Boom)?.output?.statusCode;
+      const shouldReconnect = statusCode !== DisconnectReason.loggedOut;
+      console.log(chalk.red('Conexión cerrada, razón:'), lastDisconnect.error, chalk.yellow('Reconectando...'), shouldReconnect);
       
       if (shouldReconnect) {
-        startBot()
+        connectToWhatsApp();
       }
     } else if (connection === 'open') {
-      console.log(chalk.green(`✓ Bot conectado como ${config.botName}`))
-      console.log(chalk.blue('Bot listo para recibir mensajes'))
+      console.log(chalk.green(`✓ Bot conectado como ${config.botName || sock.user.name}`));
+      console.log(chalk.blue('Cargando plugins...'));
+      await loadPlugins(plugins);
+      console.log(chalk.cyan(`Plugins cargados: ${plugins.size}`));
+      console.log(chalk.blue('Bot listo para recibir mensajes'));
     }
-  })
+  });
 
-  sock.ev.on('creds.update', saveCreds)
+  sock.ev.on('creds.update', saveCreds);
   
   sock.ev.on('messages.upsert', async (m) => {
     try {
-      const msg = m.messages[0]
-      if (!msg.message || msg.key.fromMe) return
+      const msg = m.messages[0];
+      if (!msg.message || msg.key.fromMe) return;
       
-      await handleMessage(sock, msg, plugins, errorHandler)
+      await handleMessage(sock, msg, plugins, errorHandler);
     } catch (error) {
-      console.error(chalk.red('Error procesando mensaje:'), error.message)
+      console.error(chalk.red('[error] Error procesando mensaje:'), error);
       if (errorHandler) {
-        await errorHandler.handleSystemError(error, 'Procesamiento de mensajes')
+        await errorHandler.handleSystemError(error, 'Procesamiento de mensajes');
       }
     }
-  })
-
-    // Cargar plugins
-    await loadPlugins(plugins)
-    console.log(chalk.cyan(`Plugins cargados: ${plugins.size}`))
-
-  } catch (error) {
-    console.error(chalk.red('Error crítico iniciando bot:'), error.message)
-    if (errorHandler) {
-      await errorHandler.handleSystemError(error, 'Inicio del bot')
-    }
-    // Reintentar conexión después de 10 segundos
-    setTimeout(startBot, 10000)
-  }
+  });
 }
 
-// Manejar errores no capturados
+// --- Original Process-wide Error Handlers ---
 process.on('unhandledRejection', async (error) => {
-  console.error(chalk.red('Promesa no manejada:'), error)
+  console.error(chalk.red('[error] Promesa no manejada:'), error);
   if (errorHandler) {
-    await errorHandler.handleSystemError(error, 'Promesa no manejada')
+    await errorHandler.handleSystemError(error, 'Promesa no manejada');
   }
-})
+});
 
 process.on('uncaughtException', async (error) => {
-  console.error(chalk.red('Excepción no capturada:'), error)
+  console.error(chalk.red('[error] Excepción no capturada:'), error);
   if (errorHandler) {
-    await errorHandler.handleSystemError(error, 'Excepción no capturada')
+    await errorHandler.handleSystemError(error, 'Excepción no capturada');
   }
-  process.exit(1)
-})
+  process.exit(1);
+});
 
-startBot()
+// --- Start the Bot ---
+connectToWhatsApp();
 
-export { sock }
+export { sock };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@hapi/boom": "^10.0.1",
         "@whiskeysockets/baileys": "^6.6.0",
         "axios": "^1.6.2",
         "chalk": "^5.3.0",
         "fs-extra": "^11.2.0",
+        "google-libphonenumber": "^3.2.43",
         "moment": "^2.30.1",
         "pino": "^8.21.0",
         "qrcode-terminal": "^0.12.0",
@@ -206,17 +208,19 @@
       }
     },
     "node_modules/@hapi/boom": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
-      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.1.tgz",
+      "integrity": "sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "^11.0.2"
       }
     },
     "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -676,6 +680,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@whiskeysockets/baileys/node_modules/@hapi/boom": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@whiskeysockets/baileys/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@whiskeysockets/baileys/node_modules/pino": {
       "version": "9.11.0",
@@ -1958,6 +1977,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/google-libphonenumber": {
+      "version": "3.2.43",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.43.tgz",
+      "integrity": "sha512-TbIX/UC3BFRJwCxbBeCPwuRC4Qws9Jz/CECmfTM1t9RFoI3X6eRThurv6AYr9wSrt640IA9KFIHuAD/vlyjqRw==",
+      "license": "(MIT AND Apache-2.0)",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/gopd": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
   "author": "Tu nombre",
   "license": "MIT",
   "dependencies": {
+    "@hapi/boom": "^10.0.1",
     "@whiskeysockets/baileys": "^6.6.0",
     "axios": "^1.6.2",
     "chalk": "^5.3.0",
     "fs-extra": "^11.2.0",
+    "google-libphonenumber": "^3.2.43",
     "moment": "^2.30.1",
     "pino": "^8.21.0",
     "qrcode-terminal": "^0.12.0",


### PR DESCRIPTION
- Resolves the critical `logger.child is not a function` error by correctly implementing the `pino` logger.
- Adds an interactive command-line menu to allow choosing between QR code and pairing code for the initial connection.
- Adds `google-libphonenumber` and `@hapi/boom` as dependencies for the new connection logic.
- Ensures the original plugin and message handling systems are preserved and function correctly after connection.
- Deletes the existing session directory to prevent `Stream Errored` issues from a corrupted session.